### PR TITLE
Add Android CI workflow with build and unit test jobs

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,0 +1,24 @@
+name: Setup Gradle
+description: Set up JDK 17, restore Gradle cache, and make gradlew executable
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Cache Gradle
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: gradle-${{ hashFiles('**/*.gradle*', '**/libs.versions.toml') }}
+        restore-keys: gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      shell: bash

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,44 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-gradle
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-gradle
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: app/build/reports/tests/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/android-ci.yml` with two jobs: `build` and `unit-tests`
- `build` job assembles the debug APK and uploads it as an artifact
- `unit-tests` job runs `./gradlew test` and uploads test reports (always, even on failure)

## Test plan
- [ ] Verify `build` job passes and debug APK artifact is available
- [ ] Verify `unit-tests` job passes and test results artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)