### PR TITLE
Fix: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -5,13 +5,13 @@ runs:
   using: composite
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Cache Gradle
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-gradle
 
@@ -19,7 +19,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
@@ -29,7 +29,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-gradle
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: app/build/reports/tests/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` v4 → v6
- Upgrades `actions/upload-artifact` v4 → v7
- Upgrades `actions/setup-java` v4 → v5
- Upgrades `actions/cache` v4 → v5

## Test plan
- [ ] Verify CI passes on this PR (build + unit-tests jobs)
- [ ] Confirm no Node.js 20 deprecation warnings in workflow logs

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)